### PR TITLE
Sonatype Lifecycle repository

### DIFF
--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -18,6 +18,9 @@ orgs.newOrg('eclipse-csi') {
     orgs.newRepo('gradually') {
       description: "This repository contains SDLC Security Levels for Eclipse Foundation Projects",
     },
+    orgs.newRepo('sonatype-lifecycle') {
+      description: "Configuration files and guides for deployment and usage of Sonatype Lifecycle at the Eclipse Foundation",
+    },
     orgs.newRepo('otterdog') {
       dependabot_security_updates_enabled: true,
       description: "OtterDog is a tool to manage GitHub organizations at scale using a configuration as code approach. It is actively used by the Eclipse Foundation to manage its numerous projects hosted on GitHub.",


### PR DESCRIPTION
Adding a repo `sonatype-lifecycle` to store our configuration and documentation of Sonatype Lifecycle usage