### PR TITLE
Remove required status check for otterdog as we target now python 3.1…

### DIFF
--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -109,7 +109,6 @@ orgs.newOrg('eclipse-csi') {
           },
           required_status_checks+: {
             status_checks+: [
-              "test (3.10)",
               "test (3.11)",
               "test (3.12)",
               "analyze"


### PR DESCRIPTION
…1+ only