### PR TITLE
Remove project leads bypass of mandatory PR review

### DIFF
--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -2,9 +2,6 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
 local customRuleset(name) = 
   orgs.newRepoRuleset(name) {
-    bypass_actors+: [
-      "@eclipse-csi/technology-csi-project-leads"
-    ],
     include_refs+: [
       std.format("refs/heads/%s", name),
     ],


### PR DESCRIPTION
Issue: [391](https://github.com/eclipse-csi/otterdog/issues/391)

Remove project leads ability to bypass the mandatory review of PRs rule. Ensures that all PRs undergo review regardless of the contributor.

Need a double check if only removing this setting is the correct way to go. I see `customRuleset` only referenced in the context of `otterdog`, so it shouldn't influence other repos and judging by the [Otterdog: Repository Ruleset](https://otterdog.readthedocs.io/en/latest/reference/organization/repository/ruleset/) documentation the removal of `bypass_actors` should suffice. 