### PR TITLE
Remove required code owner reviews and strict status checks

### DIFF
--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -11,9 +11,6 @@ local customRuleset(name) =
       requires_review_thread_resolution: true,
       dismisses_stale_reviews: true,
     },
-    required_status_checks+: {
-      strict: true,
-    },
     requires_linear_history: true,
   };
 
@@ -106,9 +103,6 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       ],
       rulesets: [
         customRuleset("main") {
-          required_pull_request+: {
-            requires_code_owner_review: true,
-          },
           required_status_checks+: {
             status_checks+: [
               "test (3.11)",


### PR DESCRIPTION
This PR removes the required code owner reviews for otterdog as the CODEOWNERS file has been removed now.

Also removing strict status checks as otherwise you are required to always rebase the dependabot PRs before merging.