### PR TITLE
Add new repo *pia*

### DIFF
--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -68,6 +68,26 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
         orgs.newEnvironment('test-pypi'),
       ],      
     },
+    orgs.newRepo('pia') {
+      code_scanning_default_setup_enabled: true,
+      code_scanning_default_languages: [
+        "actions",
+        "python",
+      ],
+      dependabot_security_updates_enabled: true,
+      description: "Project Identity Authority (PIA) authenticates Eclipse Foundation projects using OpenID Connect (OIDC).",
+      has_discussions: true,
+      private_vulnerability_reporting_enabled: true,
+      topics+: [
+        "python",
+        "security",
+        "supply-chain",
+        "oidc"
+      ],
+      rulesets: [
+        customRuleset("main") {
+      ],
+    },
     orgs.newRepo('otterdog') {
       code_scanning_default_setup_enabled: true,
       code_scanning_default_languages: [

--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -85,7 +85,7 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
         "oidc"
       ],
       rulesets: [
-        customRuleset("main") {
+        customRuleset("main")
       ],
     },
     orgs.newRepo('otterdog') {


### PR DESCRIPTION
*pia*, short for Project Identity Authority, will provide an oidc-based authentication broker for Eclipse Foundation projects.

The motivating use case is to authenticate SBOM uploads to https://sbom.eclipse.org from Jenkins CI and GitHub Actions. See ["SBOM Trusted Publihsing lite" Google doc](https://docs.google.com/document/d/1DuvC7vRsbJQpY9q4selLuAuAO4AUXiyEmHrK-xQ6GW0) for a problem statement and basic design.

An end-to-end POC can be found in [lukpueh/oidc-upload-demo](https://gitlab.eclipse.org/lukpueh/oidc-upload-demo) on GitLab. The "broker" component in the demo is the prototype for PIA.

Alternative naming suggestions:
* brokerDog (wordplay on eclipse-csi sister project otterDog)
* handover
* sink
* up
* anvil (metaphor for forging identity)
* `<your naming suggestion here>`