### PR TITLE
Add GitHub Action to lint jsonnet

### DIFF
--- a/.github/workflows/jsonnet-lint.yml
+++ b/.github/workflows/jsonnet-lint.yml
@@ -1,0 +1,34 @@
+name: Jsonnet Lint
+
+on:
+  pull_request:
+    paths:
+      - 'otterdog/eclipse-csi.jsonnet'
+      - '.github/workflows/jsonnet-lint.yml'
+
+env:
+  JSONNET_FILE: otterdog/eclipse-csi.jsonnet
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install
+        run: |
+          go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+
+      - name: Check format
+        run: |
+          if ! jsonnetfmt --test ${{ env.JSONNET_FILE }}; then
+
+            # Show issues
+            jsonnetfmt -i ${{ env.JSONNET_FILE }} && git diff
+
+            # Show resolution
+            echo "Please run 'jsonnetfmt -i ${{ env.JSONNET_FILE }}' locally!"
+
+            exit 1
+          fi

--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -1,9 +1,9 @@
 local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
-local customRuleset(name) = 
+local customRuleset(name) =
   orgs.newRepoRuleset(name) {
     include_refs+: [
-      std.format("refs/heads/%s", name),
+      std.format('refs/heads/%s', name),
     ],
     required_pull_request+: {
       required_approving_review_count: 1,
@@ -15,12 +15,12 @@ local customRuleset(name) =
   };
 
 local protectTags() = orgs.newRepoRuleset('tags-protection') {
-  target: "tag",
+  target: 'tag',
   include_refs: [
-    '~ALL'
+    '~ALL',
   ],
   allows_creations: true,
-  allows_deletions: false,	
+  allows_deletions: false,
   allows_updates: false,
   required_pull_request: null,
   required_status_checks: null,
@@ -28,10 +28,10 @@ local protectTags() = orgs.newRepoRuleset('tags-protection') {
 
 orgs.newOrg('technology.csi', 'eclipse-csi') {
   settings+: {
-    description: "The Eclipse CSI project",
-    discussion_source_repository: "eclipse-csi/.github",
+    description: 'The Eclipse CSI project',
+    discussion_source_repository: 'eclipse-csi/.github',
     has_discussions: true,
-    name: "Eclipse Common Security Infrastructure",
+    name: 'Eclipse Common Security Infrastructure',
     web_commit_signoff_required: false,
   },
   _repositories+:: [
@@ -39,81 +39,81 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       has_discussions: true,
     },
     orgs.newRepo('gradually') {
-      description: "This repository contains SDLC Security Levels for Eclipse Foundation Projects",
+      description: 'This repository contains SDLC Security Levels for Eclipse Foundation Projects',
     },
     orgs.newRepo('octopin') {
       dependabot_security_updates_enabled: true,
-      description: "Analyses and pins GitHub actions in your workflows.",
+      description: 'Analyses and pins GitHub actions in your workflows.',
       has_projects: false,
       topics+: [
-        "github-actions",
-        "python",
-        "security",
-        "supply-chain"
+        'github-actions',
+        'python',
+        'security',
+        'supply-chain',
       ],
       webhooks: [
         orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/octopin/285155/') {
-          content_type: "json",
+          content_type: 'json',
           events+: [
-            "create",
-            "delete",
-            "pull_request",
-            "push"
+            'create',
+            'delete',
+            'pull_request',
+            'push',
           ],
-          secret: "pass:bots/technology.csi/readthedocs.org/octopin-webhook-secret",
+          secret: 'pass:bots/technology.csi/readthedocs.org/octopin-webhook-secret',
         },
       ],
       environments: [
         orgs.newEnvironment('pypi'),
         orgs.newEnvironment('test-pypi'),
-      ],      
+      ],
     },
     orgs.newRepo('pia') {
       code_scanning_default_setup_enabled: true,
       dependabot_security_updates_enabled: true,
-      description: "Project Identity Authority (PIA) authenticates Eclipse Foundation projects using OpenID Connect (OIDC).",
+      description: 'Project Identity Authority (PIA) authenticates Eclipse Foundation projects using OpenID Connect (OIDC).',
       has_discussions: true,
       private_vulnerability_reporting_enabled: true,
       topics+: [
-        "python",
-        "security",
-        "supply-chain",
-        "oidc"
+        'python',
+        'security',
+        'supply-chain',
+        'oidc',
       ],
       rulesets: [
-        customRuleset("main")
+        customRuleset('main'),
       ],
     },
     orgs.newRepo('otterdog') {
       code_scanning_default_setup_enabled: true,
       code_scanning_default_languages: [
-        "actions",
-        "python",
+        'actions',
+        'python',
       ],
       dependabot_security_updates_enabled: true,
-      description: "OtterDog is a tool to manage GitHub organizations at scale using a configuration as code approach. It is actively used by the Eclipse Foundation to manage its numerous projects hosted on GitHub.",
+      description: 'OtterDog is a tool to manage GitHub organizations at scale using a configuration as code approach. It is actively used by the Eclipse Foundation to manage its numerous projects hosted on GitHub.',
       has_discussions: true,
       has_projects: false,
-      homepage: "https://otterdog.readthedocs.org",
+      homepage: 'https://otterdog.readthedocs.org',
       private_vulnerability_reporting_enabled: true,
       topics+: [
-        "asyncio",
-        "configuration-as-code",
-        "github-config",
-        "python",
-        "security",
-        "supply-chain"
+        'asyncio',
+        'configuration-as-code',
+        'github-config',
+        'python',
+        'security',
+        'supply-chain',
       ],
       webhooks: [
         orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/otterdog/260699/') {
-          content_type: "json",
+          content_type: 'json',
           events+: [
-            "create",
-            "delete",
-            "pull_request",
-            "push"
+            'create',
+            'delete',
+            'pull_request',
+            'push',
           ],
-          secret: "pass:bots/technology.csi/readthedocs.org/otterdog-webhook-secret",
+          secret: 'pass:bots/technology.csi/readthedocs.org/otterdog-webhook-secret',
         },
       ],
       environments: [
@@ -121,12 +121,12 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
         orgs.newEnvironment('test-pypi'),
       ],
       rulesets: [
-        customRuleset("main") {
+        customRuleset('main') {
           required_status_checks+: {
             status_checks+: [
-              "test (3.11)",
-              "test (3.12)",
-              "analyze"
+              'test (3.11)',
+              'test (3.12)',
+              'analyze',
             ],
           },
         },
@@ -134,9 +134,9 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       ],
     },
     orgs.newRepo('security-handbook') {
-      description: "This repository contains the source for the Eclipse Foundation Security Handbook.",
-      gh_pages_build_type: "workflow",
-      homepage: "https://eclipse-csi.github.io/security-handbook/",
+      description: 'This repository contains the source for the Eclipse Foundation Security Handbook.',
+      gh_pages_build_type: 'workflow',
+      homepage: 'https://eclipse-csi.github.io/security-handbook/',
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 0,
@@ -145,15 +145,15 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "main"
+            'main',
           ],
-          deployment_branch_policy: "selected",
+          deployment_branch_policy: 'selected',
         },
       ],
       rulesets: [
         orgs.newRepoRuleset('main') {
           include_refs+: [
-            "refs/heads/main",
+            'refs/heads/main',
           ],
           required_pull_request: null,
           required_status_checks: null,
@@ -161,30 +161,30 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       ],
     },
     orgs.newRepo('dependency-track') {
-      description: "Configuration files and guides for deployment and usage of Dependency Track at the Eclipse Foundation",
-      homepage: "https://sbom.eclipse.org",
+      description: 'Configuration files and guides for deployment and usage of Dependency Track at the Eclipse Foundation',
+      homepage: 'https://sbom.eclipse.org',
     },
     orgs.newRepo('sonatype-lifecycle') {
-      description: "Configuration files and guides for deployment and usage of Sonatype Lifecycle at the Eclipse Foundation",
+      description: 'Configuration files and guides for deployment and usage of Sonatype Lifecycle at the Eclipse Foundation',
     },
     orgs.newRepo('workflows') {
       dependabot_security_updates_enabled: true,
-      description: "Collection of reusable workflows.",
+      description: 'Collection of reusable workflows.',
       has_projects: false,
       has_wiki: false,
     },
     orgs.newRepo('helm-charts') {
-      description: "This repository contains the helm-charts source from Eclipse Foundation Security Infrastructure projects.",
-      gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "gh-pages",
-      gh_pages_source_path: "/",      
-      homepage: "https://eclipse-csi.github.io/helm-charts/",
+      description: 'This repository contains the helm-charts source from Eclipse Foundation Security Infrastructure projects.',
+      gh_pages_build_type: 'legacy',
+      gh_pages_source_branch: 'gh-pages',
+      gh_pages_source_path: '/',
+      homepage: 'https://eclipse-csi.github.io/helm-charts/',
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "gh-pages"
+            'gh-pages',
           ],
-          deployment_branch_policy: "selected",
+          deployment_branch_policy: 'selected',
         },
       ],
     },


### PR DESCRIPTION
* Add GitHub Action to check jssonnet format
  * jsonnet-lint cannot be used because it needs imports to resolve, which is not possible in this context
* Auto-format existing jssonet file

**Note:**
If preferred, I can add a pre-commit config file, or a regular git hook in addition, or instead, and run the hook on CI. IMO the test setup is simple enough to not require an testing layer.  