### PR TITLE
Mark octopin repository as archived

### DIFF
--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -42,6 +42,7 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       description: 'This repository contains SDLC Security Levels for Eclipse Foundation Projects',
     },
     orgs.newRepo('octopin') {
+      archived: true,
       dependabot_security_updates_enabled: true,
       description: 'Analyses and pins GitHub actions in your workflows.',
       has_projects: false,


### PR DESCRIPTION
A deprecation warning has been added to the README file, we should mark the repo as archived as well.