### PR TITLE
Enable projects feature for otterdog

### DIFF
--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -94,7 +94,7 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       dependabot_security_updates_enabled: true,
       description: 'OtterDog is a tool to manage GitHub organizations at scale using a configuration as code approach. It is actively used by the Eclipse Foundation to manage its numerous projects hosted on GitHub.',
       has_discussions: true,
-      has_projects: false,
+      has_projects: true,
       homepage: 'https://otterdog.readthedocs.org',
       private_vulnerability_reporting_enabled: true,
       topics+: [


### PR DESCRIPTION
Enable the Projects feature for Otterdog so we can better plan upcoming releases and manage our roadmap more effectively.