### PR TITLE
Add bypass actors to main ruleset for otterdog

### DIFF
--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -145,7 +145,7 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       rulesets: [
         customRuleset('main') {
           bypass_actors+: [
-            '@eclipse-csi/technology-csi-project-leads'
+            '@eclipse-csi/technology-csi-project-leads',
           ],
           required_status_checks+: {
             status_checks+: [

--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -144,6 +144,9 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       ],
       rulesets: [
         customRuleset('main') {
+          bypass_actors+: [
+            "@eclipse-csi/technology-csi-project-leads"
+          ],
           required_status_checks+: {
             status_checks+: [
               'test (3.11)',

--- a/otterdog/eclipse-csi.jsonnet
+++ b/otterdog/eclipse-csi.jsonnet
@@ -145,7 +145,7 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       rulesets: [
         customRuleset('main') {
           bypass_actors+: [
-            "@eclipse-csi/technology-csi-project-leads"
+            '@eclipse-csi/technology-csi-project-leads'
           ],
           required_status_checks+: {
             status_checks+: [
@@ -234,17 +234,17 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "main",
-            "tag:v*",
+            'main',
+            'tag:v*',
           ],
-          deployment_branch_policy: "selected",
+          deployment_branch_policy: 'selected',
         },
         orgs.newEnvironment('release'),
       ],
       rulesets: [
         orgs.newRepoRuleset('default_branch') {
           include_refs+: [
-            "~DEFAULT_BRANCH",
+            '~DEFAULT_BRANCH',
           ],
           required_pull_request: null,
           required_status_checks+: {
@@ -252,7 +252,7 @@ orgs.newOrg('technology.csi', 'eclipse-csi') {
           },
         },
         protectTags(),
-      ]
+      ],
     },
   ],
 }


### PR DESCRIPTION
fyi @mbarbero 

the current ruleset is really limiting, everytime I make a change to a PR I cant merge anymore but need to wait for an approval.

I dont plan to just commit to main but right now everything has to go through an approved PR which is kind of limiting.